### PR TITLE
Remove ?q=/node/1 from result path

### DIFF
--- a/src/EventSubscriber/RedirectRequestSubscriber.php
+++ b/src/EventSubscriber/RedirectRequestSubscriber.php
@@ -287,6 +287,7 @@ class RedirectRequestSubscriber implements EventSubscriberInterface {
     $this->context->fromRequest($request);
 
     parse_str($request->getQueryString(), $query);
+    unset($query['q']);
     $url->setOption('query', $query);
     $url->setAbsolute(TRUE);
 


### PR DESCRIPTION
System path "node/1?check=1" redirects to alias "?some-title?check=1&q=/node/1"